### PR TITLE
Switched appengine_config to use site.addsitedir()

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,8 +1,18 @@
-"""This file is loaded when starting a new application instance."""
+"""`appengine_config` gets loaded when starting a new application instance."""
 import site
 import os.path
+import sys
 
 # add `lib` as a site packages directory, so our `main` module can load
 # third-party libraries.
-site.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))
+#
+# Because addsitedir() appends the directory, added packages might be
+# ignored in favor of bundled versions earlier in the set of paths, so
+# we force lib/ to the start of the list.
 
+# break up the sys.path
+sys.path, remainder = sys.path[:1], sys.path[1:]
+# lib/ is added at the beginning.
+site.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))
+# add the remaining paths back
+sys.path.extend(remainder)

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,8 +1,8 @@
 """This file is loaded when starting a new application instance."""
-import sys
+import site
 import os.path
 
-# add `lib` subdirectory to `sys.path`, so our `main` module can load
+# add `lib` as a site packages directory, so our `main` module can load
 # third-party libraries.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
+site.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))
 


### PR DESCRIPTION
Replacing sys.path.insert() with site.addsitedir() makes it possible to import namespace package dependencies.
