### PR TITLE
Rename "bottle" variable to "app" to avoid confusion

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -6,4 +6,4 @@ threadsafe: yes
 
 handlers:
 - url: .*
-  script: main.bottle
+  script: main.app

--- a/main.py
+++ b/main.py
@@ -1,19 +1,19 @@
 from bottle import Bottle
 
-bottle = Bottle()
+app = Bottle()
 
 # Note: We don't need to call run() since our application is embedded within
 # the App Engine WSGI application server.
 
 
-@bottle.route('/')
+@app.route('/')
 def hello():
     """Return a friendly HTTP greeting."""
     return 'Hello World!'
 
 
 # Define an handler for 404 errors.
-@bottle.error(404)
+@app.error(404)
 def error_404(error):
     """Return a custom 404 error."""
     return 'Sorry, nothing at this URL.'


### PR DESCRIPTION
The “bottle” variable in main.py causes a bit of confusion if the user
changes the import to “import bottle”, such as to access
“bottle.debug(True)” (mentioned in the Bottle tutorial). The sample
isn’t technically wrong because it doesn’t make this import itself, but
this should make it easier to understand.
